### PR TITLE
Update ps1 script to create ssh config if it doesn't exist

### DIFF
--- a/codespace-remote-ssh-connect.ps1
+++ b/codespace-remote-ssh-connect.ps1
@@ -46,6 +46,9 @@ Host ${hostName}
 
 if ((Test-Path "${HOME}\.ssh\config") -ne $true -Or (Get-Content -Path "${HOME}\.ssh\config" | Select-String "Host ${hostName}" -casesensitive -quiet) -ne $true){
     New-Item -ItemType Directory -Force -Path "${HOME}\.ssh" > $null
+    if ((Test-Path "${HOME}\.ssh\config") -ne $true) {
+        New-Item -ItemType File -Force -Path "${HOME}\.ssh\config" > $null
+    }
     $sshConfig = Get-Content -Path "${HOME}\.ssh\config" -Raw
     [IO.File]::WriteAllText("${HOME}\.ssh\config", ($sshConfig+$sshConfigSnippet -replace "`r`n", "`n"))
 }


### PR DESCRIPTION
The powershell script currently checks that the config file exists, but does not create one in the event it's missing. This PR resolves that error.